### PR TITLE
Add purchase endpoint with Stripe Link checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Link MCP is a Minimal Checkout Protocol (MCP) server that exposes only products 
 - Allows sorting by price, delivery date, or other criteria
 - Supports commands like **"buy the xyz one"** to finalize a purchase
 - Uses a one-time authorization with Stripe Link for seamless checkout
+- Provides an endpoint to initiate a Checkout session for Link purchases
 
 link-mcp
 
@@ -38,7 +39,7 @@ python pytest.py
 ## Usage
 1. The LLM queries the MCP server to fetch products. Results are sorted by the criteria provided (for example, by price or delivery date).
 2. The user responds with a phrase such as **"buy the xyz one"**, referencing the desired product from the list.
-3. The MCP agent completes the transaction via Stripe Link using the stored credentials. The user only needs to authorize into Link once when first using the server.
+3. The MCP agent sends a `POST` request to `/products/<product_id>/buy` which returns a Checkout URL. The user completes the purchase by visiting this Link-enabled Checkout page.
 
 ## Contributing
 We welcome contributions!

--- a/app/routes/products.py
+++ b/app/routes/products.py
@@ -1,6 +1,7 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from app.services.product_query import list_products
 from app.services.link_filter import filter_link_eligible
+from app.services.checkout import create_link_checkout_session
 
 products_bp = Blueprint('products', __name__)
 
@@ -10,3 +11,15 @@ def get_link_products():
     products = list_products()
     link_products = filter_link_eligible(products)
     return jsonify(link_products)
+
+
+@products_bp.route('/products/<product_id>/buy', methods=['POST'])
+def buy_product(product_id):
+    """Create a Link Checkout session for the selected product."""
+    data = request.get_json(silent=True) or {}
+    success_url = data.get('success_url', 'https://example.com/success')
+    cancel_url = data.get('cancel_url', 'https://example.com/cancel')
+    session = create_link_checkout_session(product_id, success_url, cancel_url)
+    if not session:
+        return jsonify({'error': 'Unable to create checkout session'}), 500
+    return jsonify({'checkout_url': session['url']})

--- a/app/services/checkout.py
+++ b/app/services/checkout.py
@@ -1,0 +1,25 @@
+import os
+import stripe
+
+stripe.api_key = os.environ.get("STRIPE_API_KEY", "")
+
+
+def create_link_checkout_session(product_id: str, success_url: str, cancel_url: str):
+    """Create a Stripe Checkout session for Link."""
+    if not stripe.api_key:
+        return None
+
+    product = stripe.Product.retrieve(product_id, expand=["default_price"])
+    price = getattr(product, "default_price", None)
+    if not price:
+        return None
+
+    price_id = price["id"] if isinstance(price, dict) else price.id
+    session = stripe.checkout.Session.create(
+        payment_method_types=["link"],
+        mode="payment",
+        line_items=[{"price": price_id, "quantity": 1}],
+        success_url=success_url,
+        cancel_url=cancel_url,
+    )
+    return session.to_dict_recursive()

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+stripe_stub = types.ModuleType("stripe")
+stripe_stub.Product = types.SimpleNamespace(retrieve=lambda *a, **k: None)
+stripe_stub.checkout = types.SimpleNamespace(Session=types.SimpleNamespace(create=lambda **k: None))
+sys.modules.setdefault("stripe", stripe_stub)
+
+from app.services.checkout import create_link_checkout_session
+
+
+import os
+
+
+def test_create_link_checkout_session_no_api_key():
+    os.environ["STRIPE_API_KEY"] = ""
+    import app.services.checkout as checkout
+    checkout.stripe.api_key = os.environ["STRIPE_API_KEY"]
+    session = create_link_checkout_session("prod_123", "s", "c")
+    assert session is None
+
+
+def test_create_link_checkout_session_success():
+    os.environ["STRIPE_API_KEY"] = "sk_test"
+
+    class DummySession:
+        def __init__(self):
+            self.url = "https://checkout.stripe.com/session"
+
+        def to_dict_recursive(self):
+            return {"url": self.url}
+
+    dummy_product = type("Product", (), {"default_price": {"id": "price_123"}})()
+
+    stripe_stub.Product.retrieve = lambda pid, expand=None: dummy_product
+    stripe_stub.checkout.Session.create = lambda **kwargs: DummySession()
+    import app.services.checkout as checkout
+    checkout.stripe.api_key = os.environ["STRIPE_API_KEY"]
+
+    session = create_link_checkout_session("prod_123", "s", "c")
+    assert session == {"url": "https://checkout.stripe.com/session"}


### PR DESCRIPTION
## Summary
- add `/products/<product_id>/buy` route for initiating Link-enabled checkout
- support creating checkout sessions via new service
- document the new endpoint and update usage notes
- add unit tests for checkout session creation

## Testing
- `python pytest.py`